### PR TITLE
Add deserialization test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "@linyixian/node-red-contrib-aitrios-meta-desirialize",
+  "version": "0.0.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@linyixian/node-red-contrib-aitrios-meta-desirialize",
+      "version": "0.0.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "flatbuffers": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.7.tgz",
+      "integrity": "sha512-5JulPk3a7zTdb2p2ElkAT8hmw4udmSL8GoRKkDa/y9+qFwKbFrRgAbF4VgSt2oIGTEpBqz9CmsvwCstwJ5D9kg==",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   "license": "Apache-2.0",
   "author": "linyixian",
   "type": "commonjs",
-  "main": "aitrios-meta-desirialize.js"
+  "main": "aitrios-meta-desirialize.js",
+  "scripts": {
+    "test": "node test/test.js"
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const RED = { nodes: { registerType: function() {} } };
+const mod = require('../aitrios-meta-desirialize.js');
+mod(RED);
+const classes = mod.AitriosSchemaClasses;
+const data = [12,0,0,0,0,0,6,0,10,0,4,0,6,0,0,0,12,0,0,0,0,0,6,0,8,0,4,0,6,0,0,0,4,0,0,0,1,0,0,0,16,0,0,0,12,0,16,0,0,0,7,0,8,0,12,0,12,0,0,0,0,0,0,1,20,0,0,0,0,0,127,63,12,0,20,0,4,0,8,0,12,0,16,0,12,0,0,0,59,0,0,0,46,0,0,0,56,1,0,0,56,1,0,0];
+const buf = Buffer.from(data);
+const bb = new (require('flatbuffers').ByteBuffer)(buf);
+const top = classes.ObjectDetectionTop.getRootAsObjectDetectionTop(bb);
+const perception = top.perception(new classes.ObjectDetectionData());
+const result = { perception: { object_detection_list: [] } };
+for (let i = 0; i < perception.objectDetectionListLength(); i++) {
+  const obj = perception.objectDetectionList(i, new classes.GeneralObject());
+  const item = { class_id: obj.classId(), score: obj.score() };
+  if (obj.boundingBoxType() === classes.BoundingBox.BoundingBox2d) {
+    const bb2d = obj.boundingBox(new classes.BoundingBox2d());
+    item.bounding_box = {
+      left: bb2d.left(),
+      top: bb2d.top(),
+      right: bb2d.right(),
+      bottom: bb2d.bottom()
+    };
+  }
+  result.perception.object_detection_list.push(item);
+}
+const expected = {
+  perception: {
+    object_detection_list: [
+      {
+        class_id: 0,
+        score: 0.99609375,
+        bounding_box: {
+          left: 59,
+          top: 46,
+          right: 312,
+          bottom: 312
+        }
+      }
+    ]
+  }
+};
+assert.deepStrictEqual(result, expected);
+console.log('Test passed');
+


### PR DESCRIPTION
## Summary
- add script for tests in package.json
- include package-lock.json so `npm ci` works
- implement a minimal test verifying metadata decoding

## Testing
- `npm test`
- `npm ci`

------
https://chatgpt.com/codex/tasks/task_e_6846880ba4688328983d12e58da07862